### PR TITLE
getting musl to work

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -3,5 +3,6 @@ ignore = .git
 
 [cxx]
 untracked_headers = error
-cc = /usr/bin/gcc
+
+cc = /usr/bin/clang-6.0
 cxx = /usr/bin/g++

--- a/demo/BUCK
+++ b/demo/BUCK
@@ -5,6 +5,7 @@ cxx_binary(
   ], 
   compiler_flags = [
     '-nostdinc', 
+    '-DFOOBAR',
   ], 
   deps = [
     '//:musl', 

--- a/src/fenv/x86_64/fenv.s
+++ b/src/fenv/x86_64/fenv.s
@@ -1,97 +1,103 @@
+# 1 "src/fenv/x86_64/fenv.S"
+# 1 "<built-in>"
+# 1 "<command-line>"
+# 31 "<command-line>"
+# 1 "/usr/include/stdc-predef.h" 1 3 4
+# 32 "<command-line>" 2
+# 1 "src/fenv/x86_64/fenv.S"
 .global feclearexcept
 .type feclearexcept,@function
 feclearexcept:
-		# maintain exceptions in the sse mxcsr, clear x87 exceptions
-	mov %edi,%ecx
-	and $0x3f,%ecx
-	fnstsw %ax
-	test %eax,%ecx
-	jz 1f
-	fnclex
-1:	stmxcsr -8(%rsp)
-	and $0x3f,%eax
-	or %eax,-8(%rsp)
-	test %ecx,-8(%rsp)
-	jz 1f
-	not %ecx
-	and %ecx,-8(%rsp)
-	ldmxcsr -8(%rsp)
-1:	xor %eax,%eax
-	ret
+ mov %edi,%ecx
+ and $0x3f,%ecx
+ fnstsw %ax
+ test %eax,%ecx
+ jz 1f
+ fnclex
+1: stmxcsr -8(%rsp)
+ and $0x3f,%eax
+ or %eax,-8(%rsp)
+ test %ecx,-8(%rsp)
+ jz 1f
+ not %ecx
+ and %ecx,-8(%rsp)
+ ldmxcsr -8(%rsp)
+1: xor %eax,%eax
+ ret
 
 .global feraiseexcept
 .type feraiseexcept,@function
 feraiseexcept:
-	and $0x3f,%edi
-	stmxcsr -8(%rsp)
-	or %edi,-8(%rsp)
-	ldmxcsr -8(%rsp)
-	xor %eax,%eax
-	ret
+ and $0x3f,%edi
+ stmxcsr -8(%rsp)
+ or %edi,-8(%rsp)
+ ldmxcsr -8(%rsp)
+ xor %eax,%eax
+ ret
 
 .global __fesetround
 .type __fesetround,@function
 __fesetround:
-	push %rax
-	xor %eax,%eax
-	mov %edi,%ecx
-	fnstcw (%rsp)
-	andb $0xf3,1(%rsp)
-	or %ch,1(%rsp)
-	fldcw (%rsp)
-	stmxcsr (%rsp)
-	shl $3,%ch
-	andb $0x9f,1(%rsp)
-	or %ch,1(%rsp)
-	ldmxcsr (%rsp)
-	pop %rcx
-	ret
+ push %rax
+ xor %eax,%eax
+ mov %edi,%ecx
+ fnstcw (%rsp)
+ andb $0xf3,1(%rsp)
+ or %ch,1(%rsp)
+ fldcw (%rsp)
+ stmxcsr (%rsp)
+ shl $3,%ch
+ andb $0x9f,1(%rsp)
+ or %ch,1(%rsp)
+ ldmxcsr (%rsp)
+ pop %rcx
+ ret
 
 .global fegetround
 .type fegetround,@function
 fegetround:
-	push %rax
-	stmxcsr (%rsp)
-	pop %rax
-	shr $3,%eax
-	and $0xc00,%eax
-	ret
+ push %rax
+ stmxcsr (%rsp)
+ pop %rax
+ shr $3,%eax
+ and $0xc00,%eax
+ ret
 
 .global fegetenv
 .type fegetenv,@function
 fegetenv:
-	xor %eax,%eax
-	fnstenv (%rdi)
-	stmxcsr 28(%rdi)
-	ret
+ xor %eax,%eax
+ fnstenv (%rdi)
+ stmxcsr 28(%rdi)
+ ret
 
 .global fesetenv
 .type fesetenv,@function
 fesetenv:
-	xor %eax,%eax
-	inc %rdi
-	jz 1f
-	fldenv -1(%rdi)
-	ldmxcsr 27(%rdi)
-	ret
-1:	push %rax
-	push %rax
-	pushq $0xffff
-	pushq $0x37f
-	fldenv (%rsp)
-	pushq $0x1f80
-	ldmxcsr (%rsp)
-	add $40,%rsp
-	ret
+ xor %eax,%eax
+ inc %rdi
+ jz 1f
+ fldenv -1(%rdi)
+ ldmxcsr 27(%rdi)
+ ret
+1: push %rax
+ push %rax
+ pushq $0xffff
+ pushq $0x37f
+ fldenv (%rsp)
+ pushq $0x1f80
+ ldmxcsr (%rsp)
+ add $40,%rsp
+ ret
 
 .global fetestexcept
 .type fetestexcept,@function
 fetestexcept:
-	and $0x3f,%edi
-	push %rax
-	stmxcsr (%rsp)
-	pop %rsi
-	fnstsw %ax
-	or %esi,%eax
-	and %edi,%eax
-	ret
+ and $0x3f,%edi
+ push %rax
+ stmxcsr (%rsp)
+ pop %rsi
+ fnstsw %ax
+ or %esi,%eax
+ and %edi,%eax
+ ret

--- a/src/math/x86_64/acosl.s
+++ b/src/math/x86_64/acosl.s
@@ -1,5 +1,3 @@
-# see ../i386/acos.s
-
 .global acosl
 .type acosl,@function
 acosl:

--- a/src/math/x86_64/ceill.s
+++ b/src/math/x86_64/ceill.s
@@ -1,1 +1,0 @@
-# see floorl.s

--- a/src/math/x86_64/exp2l.s
+++ b/src/math/x86_64/exp2l.s
@@ -9,7 +9,6 @@ expm1l:
 	fucomip %st(1),%st
 	fld1
 	jb 1f
-		# x*log2e <= -65, return -1 without underflow
 	fstp %st(1)
 	fchs
 	ret
@@ -37,30 +36,30 @@ exp2l:
 	mov 8(%rsp),%ax
 	and $0x7fff,%ax
 	cmp $0x3fff+13,%ax
-	jb 4f             # |x| < 8192
+	jb 4f           
 	cmp $0x3fff+15,%ax
-	jae 3f            # |x| >= 32768
+	jae 3f         
 	fsts (%rsp)
 	cmpl $0xc67ff800,(%rsp)
-	jb 2f             # x > -16382
+	jb 2f         
 	movl $0x5f000000,(%rsp)
-	flds (%rsp)       # 0x1p63
+	flds (%rsp)  
 	fld %st(1)
 	fsub %st(1)
 	faddp
 	fucomip %st(1),%st
-	je 2f             # x - 0x1p63 + 0x1p63 == x
+	je 2f        
 	movl $1,(%rsp)
-	flds (%rsp)       # 0x1p-149
+	flds (%rsp) 
 	fdiv %st(1)
-	fstps (%rsp)      # raise underflow
+	fstps (%rsp)
 2:	fld1
 	fld %st(1)
 	frndint
 	fxch %st(2)
-	fsub %st(2)       # st(0)=x-rint(x), st(1)=1, st(2)=rint(x)
+	fsub %st(2) 
 	f2xm1
-	faddp             # 2^(x-rint(x))
+	faddp      
 1:	fscale
 	fstp %st(1)
 	add $16,%rsp
@@ -68,7 +67,7 @@ exp2l:
 3:	xor %eax,%eax
 4:	cmp $0x3fff-64,%ax
 	fld1
-	jb 1b             # |x| < 0x1p-64
+	jb 1b     
 	fstpt (%rsp)
 	fistl 8(%rsp)
 	fildl 8(%rsp)
@@ -76,8 +75,8 @@ exp2l:
 	addl $0x3fff,8(%rsp)
 	f2xm1
 	fld1
-	faddp             # 2^(x-rint(x))
-	fldt (%rsp)       # 2^rint(x)
+	faddp     
+	fldt (%rsp)
 	fmulp
 	add $16,%rsp
 	ret

--- a/src/math/x86_64/expl.s
+++ b/src/math/x86_64/expl.s
@@ -1,15 +1,7 @@
-# exp(x) = 2^hi + 2^hi (2^lo - 1)
-# where hi+lo = log2e*x with 128bit precision
-# exact log2e*x calculation depends on nearest rounding mode
-# using the exact multiplication method of Dekker and Veltkamp
-
 .global expl
 .type expl,@function
 expl:
 	fldt 8(%rsp)
-
-		# interesting case: 0x1p-32 <= |x| < 16384
-		# check if (exponent|0x8000) is in [0xbfff-32, 0xbfff+13]
 	mov 16(%rsp), %ax
 	or $0x8000, %ax
 	sub $0xbfdf, %ax
@@ -18,80 +10,58 @@ expl:
 	test %ax, %ax
 	fld1
 	js 1f
-		# if |x|>=0x1p14 or nan return 2^trunc(x)
 	fscale
 	fstp %st(1)
 	ret
-		# if |x|<0x1p-32 return 1+x
 1:	faddp
 	ret
 
-		# should be 0x1.71547652b82fe178p0L == 0x3fff b8aa3b29 5c17f0bc
-		# it will be wrong on non-nearest rounding mode
 2:	fldl2e
 	subq $48, %rsp
-		# hi = log2e_hi*x
-		# 2^hi = exp2l(hi)
 	fmul %st(1),%st
 	fld %st(0)
 	fstpt (%rsp)
 	fstpt 16(%rsp)
 	fstpt 32(%rsp)
 	call exp2l@PLT
-		# if 2^hi == inf return 2^hi
 	fld %st(0)
 	fstpt (%rsp)
 	cmpw $0x7fff, 8(%rsp)
 	je 1f
 	fldt 32(%rsp)
 	fldt 16(%rsp)
-		# fpu stack: 2^hi x hi
-		# exact mult: x*log2e
 	fld %st(1)
-		# c = 0x1p32+1
 	movq $0x41f0000000100000,%rax
 	pushq %rax
 	fldl (%rsp)
-		# xh = x - c*x + c*x
-		# xl = x - xh
 	fmulp
 	fld %st(2)
 	fsub %st(1), %st
 	faddp
 	fld %st(2)
 	fsub %st(1), %st
-		# yh = log2e_hi - c*log2e_hi + c*log2e_hi
 	movq $0x3ff7154765200000,%rax
 	pushq %rax
 	fldl (%rsp)
-		# fpu stack: 2^hi x hi xh xl yh
-		# lo = hi - xh*yh + xl*yh
 	fld %st(2)
 	fmul %st(1), %st
 	fsubp %st, %st(4)
 	fmul %st(1), %st
 	faddp %st, %st(3)
-		# yl = log2e_hi - yh
 	movq $0x3de705fc2f000000,%rax
 	pushq %rax
 	fldl (%rsp)
-		# fpu stack: 2^hi x lo xh xl yl
-		# lo += xh*yl + xl*yl
 	fmul %st, %st(2)
 	fmulp %st, %st(1)
 	fxch %st(2)
 	faddp
 	faddp
-		# log2e_lo
 	movq $0xbfbe,%rax
 	pushq %rax
 	movq $0x82f0025f2dc582ee,%rax
 	pushq %rax
 	fldt (%rsp)
 	addq $40,%rsp
-		# fpu stack: 2^hi x lo log2e_lo
-		# lo += log2e_lo*x
-		# return 2^hi + 2^hi (2^lo - 1)
 	fmulp %st, %st(2)
 	faddp
 	f2xm1

--- a/src/math/x86_64/expm1l.s
+++ b/src/math/x86_64/expm1l.s
@@ -1,1 +1,0 @@
-# see exp2l.s

--- a/src/math/x86_64/truncl.s
+++ b/src/math/x86_64/truncl.s
@@ -1,1 +1,0 @@
-# see floorl.s


### PR DESCRIPTION
Why this works:
1) platform specific files are used as a substitute for the generic files.
eg. use `src/*/x86_64/*.{c|s}` instead of `fenv/*.c` or both (linker wont complain because the symbols have weak linkage).

2) `#` style comments in `*.s` files removed.

seems like both gcc & buck are buggy here.
buck calls `g++/cc1 -E -Xlang=asm ${preprocessor_flags} ${cflags} -fno-directives-only`

`-fno-directives-only` performs macro expansion apparently without respecting the supplied `-Xlang`

Buck doesn't seem to use the specified preprocessor `cpp` in .buckconfig nor `cppflags` so working around this issue was not possible.

Adding `-fdirectives-only` to `preprocessor_flags` will not work either as `fno-directives-only` is added as the last flag.
